### PR TITLE
Add file list forming; disable progress bar on startup

### DIFF
--- a/ArchivedFileModel.hpp
+++ b/ArchivedFileModel.hpp
@@ -26,6 +26,7 @@ namespace yac
 		std::vector<EntryInfo*> children;
         EntryType type;
         QString name;
+		QString fullPath;
 		size_t sizeUncompressed = 0;
 		size_t sizeCompressed = 0;
 		EntryInfo& operator=(EntryInfo) = delete;

--- a/GuiInteractor.hpp
+++ b/GuiInteractor.hpp
@@ -21,6 +21,7 @@ public:
 	Q_SIGNAL void fireExtractToFolder(QUrl url);
 	Q_SIGNAL void fireConcatWith(QUrl url);
 	Q_SIGNAL void fireCancelCurrentArchivation();
+	Q_SIGNAL void fireAddFiles(std::vector<EntryInfo*> files);
 	// QML to C++ GUI-only
 	Q_SIGNAL void fireEnterFolder(QString name);
 	Q_SIGNAL void fireGoBack();
@@ -37,8 +38,8 @@ private:
 	Q_SLOT void onSetFileTree(EntryInfo* root);
 	Q_SLOT void onAddEntryToCurrentFolder(EntryInfo* entry);
 	static QString toUserFriendlyFileName(QString name);
-	EntryInfo* formEntry(QUrl url, EntryInfo* parent = nullptr);
-	EntryInfo* formEntry(QString name, EntryInfo* parent = nullptr);
+	EntryInfo* formEntry(QUrl url, std::vector<EntryInfo*>& files, EntryInfo* parent = nullptr);
+	EntryInfo* formEntry(QString name, std::vector<EntryInfo*>& files, EntryInfo* parent = nullptr);
 };
 }
 

--- a/main.qml
+++ b/main.qml
@@ -155,7 +155,7 @@ ApplicationWindow {
 
 			RowLayout {
 				id: archProgress
-	//			visible: false
+				visible: false
 				Layout.fillWidth: true
 				ProgressBar {
 					id: archPB


### PR DESCRIPTION
Добавил формирование именно списка файлов и выкидыш этого списка сигналом fireAddFiles. Добавил в EntryInfo полный путь, ибо иначе его будет сложно определить в такой ситуации: добавляем в архив Папку1, переходим в неё, добавляем в архив файл с каким-то левым путём (не тем же, что у папки1 итд). Получаем, что определить по иерархии путь к файлу в системе невозможно. И убрал прогресс-бар при запуске